### PR TITLE
Correct the spelling of the word guarantee

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -91,7 +91,7 @@
 				If you did not create a new room, you were likely sent this link. <a href="http://www.rtccopy.com">Click here to create a new room.</a><br />
 				<br />
 				<span class="small">OTR details:<br /> 
-				We offer OTR encryption on top of the encryption your browser supports. If a pre-shared password is provided and you connect to others, their identity can be garunteed.<br />
+				We offer OTR encryption on top of the encryption your browser supports. If a pre-shared password is provided and you connect to others, their identity can be guaranteed.<br />
 				Your OTR settings must match the other users in the room.<br/ >
 				<a href="white_paper.html" target="_blank">Click here for more details.</a><br /> 
 				</span>
@@ -158,7 +158,7 @@
 				<a href="white_paper.html" target="_blank">Implementation details can be found here</a>.<br />
 				<br />
 				<b>Notice</b><br />
-				You may not use this website for anything illegal or to share any material you do not have permission to share. While we have made every effort to garuntee the security of this site, the cryptographic implementation has not been independently verified, tested or audited. This website and it's owners do not assume any liability for use of this site. <br />
+				You may not use this website for anything illegal or to share any material you do not have permission to share. While we have made every effort to guarantee the security of this site, the cryptographic implementation has not been independently verified, tested or audited. This website and it's owners do not assume any liability for use of this site. <br />
 				<br />
 				<b>Privacy</b><br />
 				We do not save <i>any</i> file or chat information, nor do we have the ability to.<br />

--- a/client/js/file-io.js
+++ b/client/js/file-io.js
@@ -34,7 +34,7 @@ this.numOfChunksInFile = 10; /* set to some arbitrarily low number for right now
 
 function get_chunk_size() {
 	if (is_chrome) {
-		/* chrome can only queue up a smaller packet. This is the only way atm I can see to garuntee
+		/* chrome can only queue up a smaller packet. This is the only way atm I can see to guarantee
 		   SCTP queue is empty before trying to send again (SCTP queue being too full results in 
 		   failure to send). */
 		 

--- a/client/white_paper.html
+++ b/client/white_paper.html
@@ -115,7 +115,7 @@ Questions?<br />
 				<a href="white_paper.html" target="_blank">Implementation details can be found here</a>.<br />
 				<br />
 				<b>Notice</b><br />
-				You may not use this website for anything illegal or to share any material you do not have permission to share. While we have made every effort to garuntee the security of this site, the cryptographic implementation has not been independently verified, tested or audited. This website and it's owners do not assume any liability for use of this site. <br />
+				You may not use this website for anything illegal or to share any material you do not have permission to share. While we have made every effort to guarantee the security of this site, the cryptographic implementation has not been independently verified, tested or audited. This website and it's owners do not assume any liability for use of this site. <br />
 				<br />
 				<b>Privacy</b><br />
 				We do not save <i>any</i> file or chat information, nor do we have the ability to.<br />


### PR DESCRIPTION
I noticed this while trying out rtccopy.com :)
